### PR TITLE
feat :: 로딩 시각화, 모바일 드롭다운 애니메이션, 이미지 성능 개선

### DIFF
--- a/src/app/(main)/[datas]/[id]/page.tsx
+++ b/src/app/(main)/[datas]/[id]/page.tsx
@@ -20,6 +20,7 @@ type CommentType = {
 export default function DetailPage() {
   const [commentText, setCommentText] = useState('');
   const [role, setRole] = useState<string | null>(null);
+  const [imageLoaded, setImageLoaded] = useState(false);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [item, setItem] = useState<any>(null);
@@ -181,9 +182,15 @@ export default function DetailPage() {
             <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
               {item.image && (
                 <div className="w-full lg:w-2/5">
-                  <div className="aspect-square w-full overflow-hidden rounded-xl bg-gray-50">
+                  <div className="aspect-square w-full overflow-hidden rounded-xl bg-gray-100">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={item.image} alt="이미지" className="h-full w-full object-cover" />
+                    <img
+                      src={item.image}
+                      alt="이미지"
+                      loading="lazy"
+                      onLoad={() => setImageLoaded(true)}
+                      className={`h-full w-full object-cover transition-opacity duration-500 ${imageLoaded ? "opacity-100" : "opacity-0"}`}
+                    />
                   </div>
                 </div>
               )}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -68,7 +68,7 @@ export const Header = () => {
 
         <div className="hidden items-center gap-6 md:flex">
           {showLoading ? (
-            <span className="text-gray-400">로딩중...</span>
+            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-500" />
           ) : isLoggedIn ? (
             <button onClick={handleLogout} className="cursor-pointer text-sm font-medium">
               로그아웃
@@ -101,8 +101,11 @@ export const Header = () => {
       </div>
 
       <div
-        className={`md:hidden ${isMenuOpen ? "flex" : "hidden"} flex-col gap-4 border-t border-[#EAEAEA] bg-white px-4 py-4 shadow-sm`}
+        className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${
+          isMenuOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
+        }`}
       >
+      <div className="flex flex-col gap-4 border-t border-[#EAEAEA] bg-white px-4 py-4 shadow-sm">
         <nav className="flex flex-col gap-3 text-sm">
           {navLinks.map(({ href, label }) => (
             <Link
@@ -127,7 +130,7 @@ export const Header = () => {
         </nav>
         <div className="border-t border-[#EAEAEA] pt-3">
           {showLoading ? (
-            <span className="text-gray-400">로딩중...</span>
+            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-500" />
           ) : isLoggedIn ? (
             <button onClick={logoutAndClose} className="text-sm font-medium">
               로그아웃
@@ -143,6 +146,7 @@ export const Header = () => {
             </div>
           )}
         </div>
+      </div>
       </div>
     </header>
   );

--- a/src/components/layout/Listbox.tsx
+++ b/src/components/layout/Listbox.tsx
@@ -3,7 +3,6 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import Loading from '@/components/ui/loading';
 
 type ListItem = {
   id: string | number;
@@ -17,9 +16,10 @@ type ListboxProps = {
   item: ListItem[];
   datas: string;
   name: string;
+  isLoading?: boolean;
 };
 
-export default function Listbox({ item, datas, name }: ListboxProps) {
+export default function Listbox({ item, datas, name, isLoading }: ListboxProps) {
   const router = useRouter();
   const [searchTerm, setSearchTerm] = useState('');
   const [filteredItems, setFilteredItems] = useState<ListItem[]>(item);
@@ -64,7 +64,11 @@ export default function Listbox({ item, datas, name }: ListboxProps) {
   return (
     <div className="w-full">
       <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <p className="text-sm font-semibold text-gray-700">전체 {filteredItems.length} 건</p>
+        {isLoading ? (
+          <div className="h-4 w-20 animate-pulse rounded bg-gray-200" />
+        ) : (
+          <p className="text-sm font-semibold text-gray-700">전체 {filteredItems.length} 건</p>
+        )}
 
         <div className="flex w-full flex-col gap-2 sm:flex-row md:w-auto">
           <input
@@ -84,16 +88,39 @@ export default function Listbox({ item, datas, name }: ListboxProps) {
       </div>
 
       <hr className="border border-black my-1" />
-      {Array.isArray(filteredItems) ? (
-        <>
-          <div className="hidden md:grid md:grid-cols-5 md:text-center md:text-sm md:font-semibold md:py-2 md:border-b md:border-gray-400">
-            <p>번호</p>
-            <p>제목</p>
-            <p>작성자</p>
-            <p>등록일</p>
-            <p>조회</p>
-          </div>
+      <div className="hidden md:grid md:grid-cols-5 md:text-center md:text-sm md:font-semibold md:py-2 md:border-b md:border-gray-400">
+        <p>번호</p>
+        <p>제목</p>
+        <p>작성자</p>
+        <p>등록일</p>
+        <p>조회</p>
+      </div>
 
+      {isLoading ? (
+        <>
+          <div className="hidden md:block">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="grid grid-cols-5 border-b border-gray-200 py-3">
+                {Array.from({ length: 5 }).map((_, j) => (
+                  <div key={j} className="flex justify-center">
+                    <div className="h-4 w-16 animate-pulse rounded bg-gray-200" />
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-col divide-y divide-gray-200 md:hidden">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex flex-col gap-2 py-3">
+                <div className="h-3 w-24 animate-pulse rounded bg-gray-200" />
+                <div className="h-5 w-full animate-pulse rounded bg-gray-200" />
+                <div className="h-3 w-32 animate-pulse rounded bg-gray-200" />
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
           <div className="hidden md:block">
             {hasResults ? (
               filteredItems.map((i, index) => (
@@ -113,7 +140,6 @@ export default function Listbox({ item, datas, name }: ListboxProps) {
               <div className="py-6 text-center text-gray-500">검색 결과가 없습니다.</div>
             )}
           </div>
-
           <div className="flex flex-col divide-y divide-gray-200 md:hidden">
             {hasResults ? (
               filteredItems.map((i, index) => (
@@ -138,10 +164,6 @@ export default function Listbox({ item, datas, name }: ListboxProps) {
             )}
           </div>
         </>
-      ) : hasSearched ? (
-        <div className="py-4 text-center text-gray-500">검색 결과가 없습니다.</div>
-      ) : (
-        <Loading />
       )}
     </div>
   );

--- a/src/components/ui/list.tsx
+++ b/src/components/ui/list.tsx
@@ -15,6 +15,7 @@ type ListProps = {
 export function List({ name, data }: ListProps) {
 
   const [item, setitem] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -34,6 +35,8 @@ export function List({ name, data }: ListProps) {
         setitem(items as any);
       } catch (error) {
         console.error("Error fetching data:", error);
+      } finally {
+        setIsLoading(false);
       }
     };
 
@@ -46,7 +49,7 @@ export function List({ name, data }: ListProps) {
       <p className="text-xl font-semibold md:text-2xl">{name}</p>
       <hr className="border-[#CCCCCC] border-[1px] rounded-[5px]" />
       <div className="w-full">
-        <Listbox item={item} datas={data} name={name} />
+        <Listbox item={item} datas={data} name={name} isLoading={isLoading} />
       </div>
     </div>
 

--- a/src/util/makeDocument.tsx
+++ b/src/util/makeDocument.tsx
@@ -45,12 +45,13 @@ export default function makeDocument(text : string) {
         if(!src) return null;
         // src[1]가 src 주소임 (match 결과는 [전체, 첫번째 캡처 그룹])
 
-        return <div className="relative w-full h-[300px]"> {/* 원하는 높이 설정 */}
+        return <div className="relative w-full h-[300px]">
           <Image
             className="object-cover block mx-auto"
             src={src[0]?.props?.children}
             alt="추가된이미지"
             fill
+            loading="lazy"
           />
         </div>
       }


### PR DESCRIPTION
## 변경 사항

### 3. 로딩 상태 시각화
- Header 인증 로딩 중 `로딩중...` 텍스트 → 스피너로 교체 (데스크탑/모바일 공통)
- 모바일 드롭다운 메뉴 즉시 전환 → max-height/opacity 슬라이드 애니메이션 (300ms)
- 게시판 목록(활동/QnA/공지사항) Firebase 데이터 로딩 중 빈 화면 → 스켈레톤 UI

### 4. 이미지 웹 성능
- 활동 상세 페이지 이미지 lazy loading 적용 + 로드 완료 시 fade-in 효과
- 게시물 본문 인라인 이미지(makeDocument) lazy loading 적용
- Cloudflare Workers 배포 특성상 `unoptimized: true` 유지

## 관련 이슈
아직 없음