### PR TITLE
[2팀] 관리자 도구의 개선 및 데이터 유실 불량 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "nodemailer": "^7.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "sonner": "^2.0.7",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -18183,6 +18184,16 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ndie",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@opennextjs/cloudflare": "1.10.0",
         "@tailwindcss/postcss": "^4",
         "@types/nodemailer": "^6.4.17",
@@ -17,7 +18,9 @@
         "nodemailer": "^7.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.73.1",
         "sonner": "^2.0.7",
+        "zod": "^4.3.6",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -9016,6 +9019,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -11620,6 +11635,12 @@
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.12.tgz",
       "integrity": "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA==",
       "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -16840,6 +16861,15 @@
         "@cloudflare/workerd-windows-64": "1.20251109.0"
       }
     },
+    "node_modules/miniflare/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -17660,6 +17690,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.73.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.73.1.tgz",
+      "integrity": "sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {
@@ -19577,9 +19623,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@opennextjs/cloudflare": "1.10.0",
     "@tailwindcss/postcss": "^4",
     "@types/nodemailer": "^6.4.17",
@@ -21,7 +22,9 @@
     "nodemailer": "^7.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.73.1",
     "sonner": "^2.0.7",
+    "zod": "^4.3.6",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "nodemailer": "^7.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.7",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import FirebaseAnalytics from "@/components/FirebaseAnalytics";
 import { AuthProvider } from "@/components/providers/AuthProvider";
+import { Toaster } from "sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -78,6 +79,7 @@ export default function RootLayout({
       >
         <FirebaseAnalytics />
         <AuthProvider>{children}</AuthProvider>
+        <Toaster richColors position="bottom-right" />
       </body>
     </html>
   );

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { Suspense } from "react";
 import React, { useRef, useState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { postSchema, PostInput } from "@/lib/validation";
 import ContentInputScreen from "@/containers/write/ContentInputScreen";
 import ContentOutputScreen from "@/containers/write/ContentOutputScreen";
 import WriteFooter from "@/containers/write/WriteFooter";
@@ -21,6 +24,12 @@ export default function Write() {
 
   const { uid, isLoading: authLoading, isInitialized } = useAuthStore();
   const router = useRouter();
+
+  const { handleSubmit, formState: { errors, isSubmitting } } = useForm<PostInput>({
+    resolver: zodResolver(postSchema),
+    values: { title, content },
+    mode: "onChange",
+  });
 
   const addText = (num: string, position: number) => {
     if (content.length > 0) setContent((prevText) => prevText + "\n" + num);
@@ -64,11 +73,18 @@ export default function Write() {
           selectedOption={selectedOption}
           addText={addText}
           contentRef={contentRef}
+          errors={errors}
         />
       </Suspense>
 
       <ContentOutputScreen title={title} content={content} />
-      <WriteFooter title={title} content={content} selectedOption={selectedOption} />
+      <WriteFooter
+        title={title}
+        content={content}
+        selectedOption={selectedOption}
+        handleSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
       <FileInput addText={addText} content={content} fileRef={fileRef} />
       <Suspense fallback={<Loading />}>
         <WriteModalScreen title={title} content={content} />

--- a/src/containers/admin/OrgChartEditor.tsx
+++ b/src/containers/admin/OrgChartEditor.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { getFirebaseDb } from "@/lib/firebase";
 
 type OrgNode = {
@@ -14,8 +14,11 @@ const defaultData: OrgNode = {
   child: [],
 };
 
+const MAX_HISTORY = 20;
+
 export default function OrgChartEditor() {
   const [data, setData] = useState<OrgNode>(defaultData);
+  const [history, setHistory] = useState<OrgNode[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [selectedPath, setSelectedPath] = useState<number[] | null>(null);
@@ -27,6 +30,18 @@ export default function OrgChartEditor() {
 
   useEffect(() => {
     loadData();
+  }, []);
+
+  const handleUndoRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "z") {
+        e.preventDefault();
+        handleUndoRef.current();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
   }, []);
 
   const loadData = async () => {
@@ -62,6 +77,32 @@ export default function OrgChartEditor() {
     }
   };
 
+  const pushHistory = (currentData: OrgNode) => {
+    setHistory((prev) => {
+      const next = [...prev, JSON.parse(JSON.stringify(currentData))];
+      return next.length > MAX_HISTORY ? next.slice(-MAX_HISTORY) : next;
+    });
+  };
+
+  const handleUndo = () => {
+    setHistory((prev) => {
+      if (prev.length === 0) return prev;
+      const restored = prev[prev.length - 1];
+      setData(restored);
+      setSelectedPath(null);
+      return prev.slice(0, -1);
+    });
+  };
+  handleUndoRef.current = handleUndo;
+
+  const countDescendants = (node: OrgNode): number => {
+    if (!node.child || node.child.length === 0) return 0;
+    return node.child.reduce(
+      (sum, child) => sum + 1 + countDescendants(child),
+      0
+    );
+  };
+
   const updateNode = (path: number[], field: "name", value: string) => {
     const newData = JSON.parse(JSON.stringify(data));
     let node = newData;
@@ -81,6 +122,7 @@ export default function OrgChartEditor() {
   };
 
   const addChild = (path: number[]) => {
+    pushHistory(data);
     const newData = JSON.parse(JSON.stringify(data));
     let node = newData;
     for (const idx of path) {
@@ -93,6 +135,24 @@ export default function OrgChartEditor() {
 
   const deleteNode = (path: number[]) => {
     if (path.length === 0) return;
+
+    let target: OrgNode = data;
+    for (let i = 0; i < path.length - 1; i++) {
+      target = target.child![path[i]];
+    }
+    target = target.child![path[path.length - 1]];
+
+    const descendantCount = countDescendants(target);
+
+    if (descendantCount > 0) {
+      const confirmed = confirm(
+        `'${target.name}' 노드와 하위 ${descendantCount}개의 노드가 모두 삭제됩니다.\n계속하시겠습니까?`
+      );
+      if (!confirmed) return;
+    }
+
+    pushHistory(data);
+
     const newData = JSON.parse(JSON.stringify(data));
     let parent = newData;
     for (let i = 0; i < path.length - 1; i++) {
@@ -105,6 +165,7 @@ export default function OrgChartEditor() {
 
   const addSiblingLeft = (path: number[]) => {
     if (path.length === 0) return;
+    pushHistory(data);
     const newData = JSON.parse(JSON.stringify(data));
     let parent = newData;
     for (let i = 0; i < path.length - 1; i++) {
@@ -118,6 +179,7 @@ export default function OrgChartEditor() {
 
   const addSiblingRight = (path: number[]) => {
     if (path.length === 0) return;
+    pushHistory(data);
     const newData = JSON.parse(JSON.stringify(data));
     let parent = newData;
     for (let i = 0; i < path.length - 1; i++) {
@@ -140,6 +202,7 @@ export default function OrgChartEditor() {
     if (toStr.startsWith(fromStr) || fromStr === toStr) return;
 
     try {
+      pushHistory(data);
       const newData = JSON.parse(JSON.stringify(data));
       let fromParent = newData;
       for (let i = 0; i < fromPath.length - 1; i++) {
@@ -167,17 +230,23 @@ export default function OrgChartEditor() {
         }
         if (!toParent.child) return;
         const toIndex = toPath[toPath.length - 1];
-        const sameParent = fromPath.slice(0, -1).join("-") === toPath.slice(0, -1).join("-");
+        const sameParent =
+          fromPath.slice(0, -1).join("-") === toPath.slice(0, -1).join("-");
         fromParent.child.splice(fromIndex, 1);
         let adjustedToIndex = toIndex;
         if (sameParent && fromIndex < toIndex) {
           adjustedToIndex = toIndex - 1;
         }
-        const insertIndex = position === "left" ? adjustedToIndex : adjustedToIndex + 1;
+        const insertIndex =
+          position === "left" ? adjustedToIndex : adjustedToIndex + 1;
         const newLevel =
-          toParent.child[Math.min(adjustedToIndex, toParent.child.length - 1)]?.level ||
-          toParent.level + 1;
-        toParent.child.splice(insertIndex, 0, recalculateLevels(movedNode, newLevel));
+          toParent.child[Math.min(adjustedToIndex, toParent.child.length - 1)]
+            ?.level ?? toParent.level + 1;
+        toParent.child.splice(
+          insertIndex,
+          0,
+          recalculateLevels(movedNode, newLevel)
+        );
       }
       setData(newData);
     } catch (error) {
@@ -241,9 +310,15 @@ export default function OrgChartEditor() {
     const isSelected = selectedPath?.join("-") === path.join("-");
     const isRoot = path.length === 0;
     const isDragging = draggedPath?.join("-") === path.join("-");
-    const isDropLeft = dropTarget?.path.join("-") === path.join("-") && dropTarget?.position === "left";
-    const isDropRight = dropTarget?.path.join("-") === path.join("-") && dropTarget?.position === "right";
-    const isDropChild = dropTarget?.path.join("-") === path.join("-") && dropTarget?.position === "child";
+    const isDropLeft =
+      dropTarget?.path.join("-") === path.join("-") &&
+      dropTarget?.position === "left";
+    const isDropRight =
+      dropTarget?.path.join("-") === path.join("-") &&
+      dropTarget?.position === "right";
+    const isDropChild =
+      dropTarget?.path.join("-") === path.join("-") &&
+      dropTarget?.position === "child";
     const hasChildren = node.child && node.child.length > 0;
 
     return (
@@ -345,17 +420,17 @@ export default function OrgChartEditor() {
             <div className="relative">
               {/* 수평 연결선 (SVG) */}
               {node.child!.length > 1 && (
-                <svg 
-                  className="absolute top-0 left-0 w-full overflow-visible" 
+                <svg
+                  className="absolute top-0 left-0 w-full overflow-visible"
                   height="2"
-                  style={{ transform: 'translateY(-1px)' }}
+                  style={{ transform: "translateY(-1px)" }}
                 >
-                  <line 
-                    x1="50" 
-                    y1="1" 
+                  <line
+                    x1="50"
+                    y1="1"
                     x2={`calc(100% - 50px)`}
-                    y2="1" 
-                    stroke="#9CA3AF" 
+                    y2="1"
+                    stroke="#9CA3AF"
                     strokeWidth="2"
                   />
                 </svg>
@@ -384,7 +459,17 @@ export default function OrgChartEditor() {
   return (
     <div>
       <div className="flex justify-between items-center mb-6">
-        <h2 className="text-xl font-bold">조직도 관리</h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-bold">조직도 관리</h2>
+          <button
+            onClick={handleUndo}
+            disabled={history.length === 0}
+            className="px-3 py-1.5 bg-gray-200 text-gray-700 text-sm rounded-lg hover:bg-gray-300 disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Ctrl+Z"
+          >
+            ↩ 되돌리기 <span className="text-gray-400 text-xs">(Ctrl+Z)</span>
+          </button>
+        </div>
         <button
           onClick={saveData}
           disabled={saving}
@@ -394,7 +479,7 @@ export default function OrgChartEditor() {
         </button>
       </div>
 
-      <div 
+      <div
         className="flex justify-center py-8 overflow-auto min-h-[400px]"
         onClick={() => setSelectedPath(null)}
       >
@@ -404,6 +489,7 @@ export default function OrgChartEditor() {
       <div className="mt-6 p-4 bg-gray-100 rounded-lg text-sm text-gray-600 space-y-1">
         <p>• 노드를 <strong>드래그</strong>하여 좌/우/하위로 이동</p>
         <p>• 노드 <strong>클릭</strong> → 편집 버튼 (← ↓ → ×)</p>
+        <p>• <strong>Ctrl+Z</strong> 또는 되돌리기 버튼으로 최대 {MAX_HISTORY}단계 복구 가능</p>
       </div>
     </div>
   );

--- a/src/containers/admin/SiteEditor.tsx
+++ b/src/containers/admin/SiteEditor.tsx
@@ -128,9 +128,11 @@ export default function SiteEditor() {
   useUnsavedGuard(isDirty);
 
   const configRef = useRef(config);
-  configRef.current = config;
-
   const draftRestoredRef = useRef(false);
+
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
 
   useEffect(() => {
     loadConfig();
@@ -151,52 +153,56 @@ export default function SiteEditor() {
   }, [isDirty]);
 
   const loadConfig = async () => {
+    let draftRestored = false;
+    if (!draftRestoredRef.current) {
+      draftRestoredRef.current = true;
+      try {
+        const raw = localStorage.getItem(DRAFT_KEY);
+        if (raw) {
+          const draft = JSON.parse(raw) as SiteConfig;
+          const ok = window.confirm(
+            "이전에 저장되지 않은 임시 데이터가 있습니다.\n복원하시겠습니까?"
+          );
+          if (ok) {
+            setConfig(draft);
+            setIsDirty(true);
+            toast.success("임시 저장 데이터를 복원했습니다.");
+            draftRestored = true;
+          } else {
+            localStorage.removeItem(DRAFT_KEY);
+          }
+        }
+      } catch {
+        localStorage.removeItem(DRAFT_KEY);
+      }
+    }
+
     try {
       const db = await getFirebaseDb();
-      if (!db) return;
-
-      const { doc, getDoc } = await import("firebase/firestore");
-      const docRef = doc(db, "siteConfig", "main");
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        const data = docSnap.data();
-        setConfig({
-          ...defaultConfig,
-          ...data,
-          banner: { ...defaultConfig.banner, ...data.banner },
-          intro: { ...defaultConfig.intro, ...data.intro },
-          theme: { ...defaultConfig.theme, ...data.theme },
-          footer: { ...defaultConfig.footer, ...data.footer },
-          header: { ...defaultConfig.header, ...data.header },
-          social: { ...defaultConfig.social, ...data.social },
-          seo: { ...defaultConfig.seo, ...data.seo },
-        });
+      if (db) {
+        const { doc, getDoc } = await import("firebase/firestore");
+        const docRef = doc(db, "siteConfig", "main");
+        const docSnap = await getDoc(docRef);
+        if (docSnap.exists() && !draftRestored) {
+          const data = docSnap.data();
+          setConfig({
+            ...defaultConfig,
+            ...data,
+            banner: { ...defaultConfig.banner, ...data.banner },
+            intro: { ...defaultConfig.intro, ...data.intro },
+            theme: { ...defaultConfig.theme, ...data.theme },
+            footer: { ...defaultConfig.footer, ...data.footer },
+            header: { ...defaultConfig.header, ...data.header },
+            social: { ...defaultConfig.social, ...data.social },
+            seo: { ...defaultConfig.seo, ...data.seo },
+          });
+        }
       }
     } catch (e) {
       console.error("사이트 설정 로드 실패:", e);
+      if (!draftRestored) setConfig(defaultConfig);
     } finally {
       setLoading(false);
-    }
-
-    if (draftRestoredRef.current) return;
-    draftRestoredRef.current = true;
-
-    try {
-      const raw = localStorage.getItem(DRAFT_KEY);
-      if (!raw) return;
-      const draft = JSON.parse(raw) as SiteConfig;
-      const ok = window.confirm(
-        "이전에 저장되지 않은 임시 데이터가 있습니다.\n복원하시겠습니까?"
-      );
-      if (ok) {
-        setConfig(draft);
-        setIsDirty(true);
-        toast.success("임시 저장 데이터를 복원했습니다.");
-      } else {
-        localStorage.removeItem(DRAFT_KEY);
-      }
-    } catch {
-      localStorage.removeItem(DRAFT_KEY);
     }
   };
 
@@ -210,10 +216,10 @@ export default function SiteEditor() {
       await setDoc(doc(db, "siteConfig", "main"), config);
       localStorage.removeItem(DRAFT_KEY);
       setIsDirty(false);
-      toast.success("저장되었습니다!");
+      alert("저장되었습니다!");
     } catch (e) {
       console.error("저장 실패:", e);
-      toast.error("저장에 실패했습니다.");
+      alert("저장에 실패했습니다.");
     } finally {
       setSaving(false);
     }

--- a/src/containers/admin/SiteEditor.tsx
+++ b/src/containers/admin/SiteEditor.tsx
@@ -1,6 +1,10 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { getFirebaseDb } from "@/lib/firebase";
+import { useUnsavedGuard } from "@/hooks/useUnsavedGuard";
+
+const DRAFT_KEY = "siteEditor_draft";
 
 export type SiteConfig = {
   // 메인 배너
@@ -119,11 +123,32 @@ export default function SiteEditor() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [activeSection, setActiveSection] = useState<SectionType>("banner");
-  const [hasChanges, setHasChanges] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useUnsavedGuard(isDirty);
+
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  const draftRestoredRef = useRef(false);
 
   useEffect(() => {
     loadConfig();
   }, []);
+
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const interval = setInterval(() => {
+      try {
+        localStorage.setItem(DRAFT_KEY, JSON.stringify(configRef.current));
+        toast.info("임시 저장되었습니다.", { duration: 2000 });
+      } catch {
+      }
+    }, 30_000);
+
+    return () => clearInterval(interval);
+  }, [isDirty]);
 
   const loadConfig = async () => {
     try {
@@ -152,6 +177,27 @@ export default function SiteEditor() {
     } finally {
       setLoading(false);
     }
+
+    if (draftRestoredRef.current) return;
+    draftRestoredRef.current = true;
+
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      if (!raw) return;
+      const draft = JSON.parse(raw) as SiteConfig;
+      const ok = window.confirm(
+        "이전에 저장되지 않은 임시 데이터가 있습니다.\n복원하시겠습니까?"
+      );
+      if (ok) {
+        setConfig(draft);
+        setIsDirty(true);
+        toast.success("임시 저장 데이터를 복원했습니다.");
+      } else {
+        localStorage.removeItem(DRAFT_KEY);
+      }
+    } catch {
+      localStorage.removeItem(DRAFT_KEY);
+    }
   };
 
   const saveConfig = async () => {
@@ -162,11 +208,12 @@ export default function SiteEditor() {
 
       const { doc, setDoc } = await import("firebase/firestore");
       await setDoc(doc(db, "siteConfig", "main"), config);
-      alert("저장되었습니다!");
-      setHasChanges(false);
+      localStorage.removeItem(DRAFT_KEY);
+      setIsDirty(false);
+      toast.success("저장되었습니다!");
     } catch (e) {
       console.error("저장 실패:", e);
-      alert("저장에 실패했습니다.");
+      toast.error("저장에 실패했습니다.");
     } finally {
       setSaving(false);
     }
@@ -184,13 +231,13 @@ export default function SiteEditor() {
         [field]: value,
       },
     }));
-    setHasChanges(true);
+    setIsDirty(true);
   };
 
   const resetToDefault = () => {
     if (confirm("모든 설정을 기본값으로 초기화하시겠습니까?")) {
       setConfig(defaultConfig);
-      setHasChanges(true);
+      setIsDirty(true);
     }
   };
 
@@ -211,7 +258,7 @@ export default function SiteEditor() {
       <div className="flex justify-between items-center mb-6">
         <div className="flex items-center gap-3">
           <h2 className="text-xl font-bold">사이트 디자인 편집</h2>
-          {hasChanges && (
+          {isDirty && (
             <span className="px-2 py-1 bg-yellow-100 text-yellow-700 text-xs rounded-full">
               저장되지 않은 변경사항
             </span>
@@ -226,7 +273,7 @@ export default function SiteEditor() {
           </button>
           <button
             onClick={saveConfig}
-            disabled={saving || !hasChanges}
+            disabled={saving || !isDirty}
             className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 disabled:opacity-50"
           >
             {saving ? "저장 중..." : "저장하기"}
@@ -256,7 +303,7 @@ export default function SiteEditor() {
       <div className="space-y-6">
         {activeSection === "banner" && <BannerEditor config={config} updateConfig={updateConfig} />}
         {activeSection === "intro" && <IntroEditor config={config} updateConfig={updateConfig} />}
-        {activeSection === "header" && <HeaderEditor config={config} updateConfig={updateConfig} setConfig={setConfig} setHasChanges={setHasChanges} />}
+        {activeSection === "header" && <HeaderEditor config={config} updateConfig={updateConfig} setConfig={setConfig} setIsDirty={setIsDirty} />}
         {activeSection === "theme" && <ThemeEditor config={config} updateConfig={updateConfig} />}
         {activeSection === "footer" && <FooterEditor config={config} updateConfig={updateConfig} />}
         {activeSection === "social" && <SocialEditor config={config} updateConfig={updateConfig} />}
@@ -279,7 +326,7 @@ type EditorProps = {
 
 type HeaderEditorProps = EditorProps & {
   setConfig: React.Dispatch<React.SetStateAction<SiteConfig>>;
-  setHasChanges: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsDirty: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 // 배너 에디터
@@ -422,7 +469,7 @@ function IntroEditor({ config, updateConfig }: EditorProps) {
 }
 
 // 헤더/메뉴 에디터
-function HeaderEditor({ config, updateConfig, setConfig, setHasChanges }: HeaderEditorProps) {
+function HeaderEditor({ config, updateConfig, setConfig, setIsDirty }: HeaderEditorProps) {
   const addMenuItem = () => {
     setConfig((prev) => ({
       ...prev,
@@ -431,7 +478,7 @@ function HeaderEditor({ config, updateConfig, setConfig, setHasChanges }: Header
         menuItems: [...prev.header.menuItems, { label: "새 메뉴", href: "/", visible: true }],
       },
     }));
-    setHasChanges(true);
+    setIsDirty(true);
   };
 
   const updateMenuItem = (index: number, field: string, value: string | boolean) => {
@@ -444,7 +491,7 @@ function HeaderEditor({ config, updateConfig, setConfig, setHasChanges }: Header
         ),
       },
     }));
-    setHasChanges(true);
+    setIsDirty(true);
   };
 
   const removeMenuItem = (index: number) => {
@@ -455,7 +502,7 @@ function HeaderEditor({ config, updateConfig, setConfig, setHasChanges }: Header
         menuItems: prev.header.menuItems.filter((_, i) => i !== index),
       },
     }));
-    setHasChanges(true);
+    setIsDirty(true);
   };
 
   return (

--- a/src/containers/write/ContentInputScreen.tsx
+++ b/src/containers/write/ContentInputScreen.tsx
@@ -12,6 +12,8 @@ import UnderLine from "@/assets/write/underline.svg";
 import ImgGray from "@/assets/write/imgGraymini.svg";
 import Img from "@/assets/write/img.svg";
 import React, { RefObject, useState } from "react";
+import { FieldErrors } from "react-hook-form";
+import { PostInput } from "@/lib/validation";
 
 import { useAuthStore } from "@/store/useAuthStore";
 
@@ -24,7 +26,8 @@ export default function ContentInputScreen(
     setTitle,
     fileRef,
     addText,
-    contentRef
+    contentRef,
+    errors,
   }:
     {
       title: string,
@@ -35,7 +38,8 @@ export default function ContentInputScreen(
       setTitle: React.Dispatch<React.SetStateAction<string>>,
       fileRef: RefObject<HTMLInputElement | null>;
       addText: (text: string, index: number) => void,
-      contentRef: RefObject<HTMLTextAreaElement | null>
+      contentRef: RefObject<HTMLTextAreaElement | null>,
+      errors?: FieldErrors<PostInput>,
     }
 ) {
 
@@ -107,13 +111,18 @@ export default function ContentInputScreen(
           </div>
         </div>
       </section>
-      <input
-        className={"w-full h-12 text-3xl font-semibold mb-4 outline-none"}
-        placeholder={"제목을 입력해주세요"}
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        spellCheck="false"
-      />
+      <div className="w-full">
+        <input
+          className={"w-full h-12 text-3xl font-semibold outline-none"}
+          placeholder={"제목을 입력해주세요"}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          spellCheck="false"
+        />
+        {errors?.title && (
+          <p className="text-red-500 text-sm mt-1">{errors.title.message}</p>
+        )}
+      </div>
       <div className="w-full overflow-scroll flex justify-center border-y-[1.5px] border-[#838383]  select-none">
         <div className="flex">
           <div
@@ -206,17 +215,20 @@ export default function ContentInputScreen(
           </div>
         </div>
       </div>
-      <textarea
-        className={"w-full h-full resize-none outline-none"}
-        onKeyDown={(e) => handleDown(e)}
-        placeholder={"내용을 입력해주세요"}
-        value={content}
-        ref={contentRef}
-        onChange={(e) => {
-          handleInput(e)
-        }}
-        spellCheck="false"
-      />
+      <div className="w-full h-full flex flex-col">
+        <textarea
+          className={"w-full h-full resize-none outline-none"}
+          onKeyDown={(e) => handleDown(e)}
+          placeholder={"내용을 입력해주세요"}
+          value={content}
+          ref={contentRef}
+          onChange={(e) => handleInput(e)}
+          spellCheck="false"
+        />
+        {errors?.content && (
+          <p className="text-red-500 text-sm mt-1">{errors.content.message}</p>
+        )}
+      </div>
     </div>
 
   )

--- a/src/containers/write/WriteFooter.tsx
+++ b/src/containers/write/WriteFooter.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { UseFormHandleSubmit } from "react-hook-form";
+import { PostInput } from "@/lib/validation";
 import { useModalStore } from "@/store/modal";
 import { CreateQA } from "@/app/api/q&a";
 import { CreateAnnouncement } from "@/app/api/announcement";
@@ -10,20 +12,22 @@ export default function WriteFooter({
   title,
   content,
   selectedOption,
+  handleSubmit,
+  isSubmitting,
 }: {
-  title: string,
-  content: string,
-  selectedOption: string,
+  title: string;
+  content: string;
+  selectedOption: string;
+  handleSubmit: UseFormHandleSubmit<PostInput>;
+  isSubmitting: boolean;
 }) {
   const { toggleModal } = useModalStore();
   const router = useRouter();
   const { setIsLoadingTrue, setIsLoadingFalse } = useLoadingStore();
-
-  // ... inside component ...
   const { role } = useAuthStore();
 
   const ensureAdmin = () => {
-    if (role !== 'ADMIN') {
+    if (role !== "ADMIN") {
       alert("관리자 권한이 필요합니다.");
       router.push("/");
       return false;
@@ -42,61 +46,53 @@ export default function WriteFooter({
         return null;
       }
 
-      // 이미 유저가 있다면 즉시 반환
       if (auth.currentUser) {
-        console.log('[WriteFooter] 현재 로그인된 사용자:', auth.currentUser.email);
         return auth.currentUser;
       }
 
-      console.log('[WriteFooter] Firebase Auth 상태 복원 대기 중...');
+      return new Promise<{ displayName?: string | null; email?: string | null } | null>(
+        (resolve) => {
+          let resolved = false;
 
-      // 없다면 상태 변화를 기다림 (최대 10초로 증가)
-      return new Promise<{ displayName?: string | null; email?: string | null } | null>((resolve) => {
-        let resolved = false;
-        
-        const timeout = setTimeout(() => {
-          if (!resolved) {
-            resolved = true;
-            unsubscribe();
-            console.error('[WriteFooter] Firebase Auth 상태 복원 타임아웃');
-            alert("로그인 정보를 불러오는데 실패했습니다. 다시 로그인해주세요.");
-            router.push("/login");
-            resolve(null);
-          }
-        }, 10000);
-
-        const unsubscribe = onAuthStateChanged(auth, (user) => {
-          console.log('[WriteFooter] onAuthStateChanged 호출:', user?.email || 'null');
-          if (!resolved) {
-            if (user) {
+          const timeout = setTimeout(() => {
+            if (!resolved) {
               resolved = true;
-              clearTimeout(timeout);
               unsubscribe();
-              resolve(user);
+              alert("로그인 정보를 불러오는데 실패했습니다. 다시 로그인해주세요.");
+              router.push("/login");
+              resolve(null);
             }
-            // user가 null이면 타임아웃까지 기다림 (초기 null 상태일 수 있음)
-          }
-        });
-      });
+          }, 10000);
+
+          const unsubscribe = onAuthStateChanged(auth, (user) => {
+            if (!resolved) {
+              if (user) {
+                resolved = true;
+                clearTimeout(timeout);
+                unsubscribe();
+                resolve(user);
+              }
+            }
+          });
+        }
+      );
     } catch (e) {
-      console.error('[WriteFooter] 로그인 확인 오류:', e);
+      console.error("[WriteFooter] 로그인 확인 오류:", e);
       alert("로그인 확인 중 오류가 발생했습니다.");
       return null;
     }
   };
 
-  const createDocument = async () => {
-    if (!title) return alert("제목을 입력해주세요")
-    if (!content) return alert("내용을 입력해주세요")
-    if (selectedOption === "") return alert("카테고리를 선택해주세요")
+  const onSubmit = async () => {
+    if (selectedOption === "") return alert("카테고리를 선택해주세요");
 
-    // 공지사항, 활동은 관리자만 작성 가능
     if (selectedOption === "공지사항" || selectedOption === "활동") {
       if (!ensureAdmin()) return;
     }
 
-    if (selectedOption === "활동") toggleModal();
-    else if (selectedOption === "공지사항") {
+    if (selectedOption === "활동") {
+      toggleModal();
+    } else if (selectedOption === "공지사항") {
       setIsLoadingTrue();
       const result = await CreateAnnouncement({ title, content });
       setIsLoadingFalse();
@@ -105,13 +101,12 @@ export default function WriteFooter({
       } else {
         alert(result.message || "공지사항 작성에 실패했습니다.");
       }
-    }
-    else if (selectedOption === "Q&A") {
-      const user = await ensureLoggedIn(); // 로그인 체크
+    } else if (selectedOption === "Q&A") {
+      const user = await ensureLoggedIn();
       if (!user) return;
 
       setIsLoadingTrue();
-      const username = user.displayName || user.email?.split('@')[0] || "익명";
+      const username = user.displayName || user.email?.split("@")[0] || "익명";
       const result = await CreateQA({ title, content, username });
       setIsLoadingFalse();
       if (result.status === 200) {
@@ -120,15 +115,18 @@ export default function WriteFooter({
         alert(result.message || "Q&A 작성에 실패했습니다.");
       }
     }
-  }
+  };
+
   return (
-    <footer className=" gap-4 h-[5.25rem] w-full fixed bottom-0 left-0 right-0 pl-15 pr-15 flex justify-end text-white items-center">
+    <footer className="gap-4 h-[5.25rem] w-full fixed bottom-0 left-0 right-0 pl-15 pr-15 flex justify-end text-white items-center">
       <button
-        onClick={() => createDocument()}
-        className={" bg-[#ED9735] text-white font-bold cursor-pointer h-[2.5rem] w-[6.5rem] rounded-[0.625rem] border-2 border-[#ED9735] text-sm flex justify-center items-center"}
+        type="submit"
+        onClick={handleSubmit(onSubmit)}
+        disabled={isSubmitting}
+        className="bg-[#ED9735] text-white font-bold cursor-pointer h-[2.5rem] w-[6.5rem] rounded-[0.625rem] border-2 border-[#ED9735] text-sm flex justify-center items-center disabled:opacity-60 disabled:cursor-not-allowed"
       >
-        등록하기
+        {isSubmitting ? "등록 중..." : "등록하기"}
       </button>
     </footer>
-  )
+  );
 }

--- a/src/containers/write/WriteFooter.tsx
+++ b/src/containers/write/WriteFooter.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { UseFormHandleSubmit } from "react-hook-form";
 import { PostInput } from "@/lib/validation";
 import { useModalStore } from "@/store/modal";
@@ -21,6 +21,8 @@ export default function WriteFooter({
   handleSubmit: UseFormHandleSubmit<PostInput>;
   isSubmitting: boolean;
 }) {
+  const [isPending, setIsPending] = useState(false);
+
   const { toggleModal } = useModalStore();
   const router = useRouter();
   const { setIsLoadingTrue, setIsLoadingFalse } = useLoadingStore();
@@ -83,7 +85,7 @@ export default function WriteFooter({
     }
   };
 
-  const onSubmit = async () => {
+  const submitDocument = async () => {
     if (selectedOption === "") return alert("카테고리를 선택해주세요");
 
     if (selectedOption === "공지사항" || selectedOption === "활동") {
@@ -117,15 +119,27 @@ export default function WriteFooter({
     }
   };
 
+  const onValid = async () => {
+    if (isPending) return;
+    setIsPending(true);
+    try {
+      await submitDocument();
+    } catch (error) {
+      console.error("[WriteFooter] 제출 오류:", error);
+    } finally {
+      setIsPending(false);
+    }
+  };
+
   return (
     <footer className="gap-4 h-[5.25rem] w-full fixed bottom-0 left-0 right-0 pl-15 pr-15 flex justify-end text-white items-center">
       <button
         type="submit"
-        onClick={handleSubmit(onSubmit)}
-        disabled={isSubmitting}
+        onClick={handleSubmit(onValid)}
+        disabled={isSubmitting || isPending}
         className="bg-[#ED9735] text-white font-bold cursor-pointer h-[2.5rem] w-[6.5rem] rounded-[0.625rem] border-2 border-[#ED9735] text-sm flex justify-center items-center disabled:opacity-60 disabled:cursor-not-allowed"
       >
-        {isSubmitting ? "등록 중..." : "등록하기"}
+        {isSubmitting || isPending ? "등록 중..." : "등록하기"}
       </button>
     </footer>
   );

--- a/src/hooks/useUnsavedGuard.ts
+++ b/src/hooks/useUnsavedGuard.ts
@@ -1,0 +1,55 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+const MESSAGE = "저장되지 않은 변경사항이 있습니다. 페이지를 이탈하시겠습니까?";
+
+export function useUnsavedGuard(isDirty: boolean) {
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirtyRef.current) return;
+      e.preventDefault();
+      e.returnValue = MESSAGE;
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
+
+  useEffect(() => {
+    const originalPushState = history.pushState.bind(history);
+    const originalReplaceState = history.replaceState.bind(history);
+
+    const intercept = (
+      original: typeof history.pushState,
+      ...args: Parameters<typeof history.pushState>
+    ) => {
+      if (isDirtyRef.current) {
+        const ok = window.confirm(MESSAGE);
+        if (!ok) return;
+      }
+      original(...args);
+    };
+
+    history.pushState = (...args) => intercept(originalPushState, ...args);
+    history.replaceState = (...args) => intercept(originalReplaceState, ...args);
+
+    const handlePopState = () => {
+      if (!isDirtyRef.current) return;
+      const ok = window.confirm(MESSAGE);
+      if (!ok) {
+        history.go(1);
+      }
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, []);
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const postSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "제목을 입력해주세요.")
+    .max(100, "제목은 100자 이내로 입력해 주세요."),
+  content: z
+    .string()
+    .trim()
+    .min(10, "내용을 10자 이상 입력해주세요."),
+});
+
+export type PostInput = z.infer<typeof postSchema>;


### PR DESCRIPTION
---
# [PR] 관리자 도구 안정성 개선 및 데이터 유실 결함 수정
## 1. 개요
- 관리자 페이지 운영 중 발생할 수 있는 데이터 유실 및 무결성 파괴 결함 3건을 파악하여 해결했습니다.
- 오조작을 시스템적으로 방지하고 데이터 품질을 확보하는 데 초점을 맞췄습니다.
---
## 2.주요 수정 내용
**SiteEditor: 저장 전 이탈 시 변경사항 유실 수정**
- **문제** : 배너, SEO 등 다수의 필드 편집 중 탭 닫기나 라우팅 이동 시 수정 데이터가 즉시 휘발됨.
- **해결** :
  - `useUnsavedGuard` 커스텀 훅을 구현하여 브라우저 종료/새로고침/뒤로가기 시 이탈 방지 가드 적용.
  - **자동 저장** : `localStorage`를 활용해 30초 주기로 편집본을 자동 임시저장.
  - **Draft 복구** : 페이지 재진입 시 기존 편집 데이터가 있으면 복원 여부를 묻는 팝업 로직 추가.

**OrgChartEditor: 노드 삭제 시 확인 절차 및 복구 기능 도입**
- **문제** : 삭제 시 하위 트리까지 영구 삭제되나 확인 절차나 Undo 기능이 없어 데이터 파괴 위험이 큼.
- **해결** :
  - **재귀적 노드 카운팅** : 삭제 전 "하위 N개 노드 포함 삭제" 문구를 명시하여 인지 편향 방지.
  - **Undo 시스템** : 히스토리 스택(20단계) 기반의 되돌리기 기능 구현.
  - **단축키 지원** : `Ctrl+Z` / `Cmd+Z` 핸들러를 추가하여 편집 편의성 개선.

**폼 제출 유효성 검사 누락 및 중복 생성 결함 수정**
- **문제** : 빈 제목/내용으로 문서 생성이 가능하여 DB가 오염되고 목록 UI가 깨지는 현상.
- **해결** :
  - **Zod 스키마 정의** : `src/lib/validation.ts`에 게시글 규격(trim 처리, 최소 길이 등) 강제.
  - **2중 제출 잠금** : `isSubmitting`(RHF)과 `isPending`(명시적 상태)을 조합해 네트워크 지연 중 중복 클릭 방지.
  - **인라인 에러** : 필드 하단에 실시간 검증 메시지를 노출하여 사용자 피드백 강화.
---
## 3. 변경 파일 요약
| 구분 | 파일 경로 | 주요 역할 |
| :--- | :---: | ---: |
| Hooks | `src/hooks/useUnsavedGuard.ts` | 페이지 이탈 방지 공통 로직 |
| Logic | `src/lib/validation.ts` | Zod 기반 데이터 검증 스키마 |
| UI | `src/containers/admin/SiteEditor.tsx` | 자동 저장 및 복구 UI 연동 |
| UI | `src/containers/admin/OrgChartEditor.tsx` | Undo 기능 및 삭제 확인 모달 적용 |
| UI | `src/containers/write/WriteFooter.tsx` | 유효성 검사 및 중복 제출 방지 로직 |
| Config | `package.json` | `zod`, `react-hook-form`, `sonner` 패키지 추가 |
---
## 4. 테스트 결과
- [x] SiteEditor: 필드 수정 중 탭 닫기 시 이탈 방지 팝업 노출 확인.
- [x] SiteEditor: 재접속 시 로컬 스토리지 데이터 복구 팝업 정상 작동 확인.
- [x] OrgChart: 하위 노드 삭제 시 카운트 정상 표시 및 삭제 후 Ctrl+Z 복구 확인.
- [x] Write: 빈 제목 입력 시 '등록' 차단 및 에러 메시지 노출 확인.
- [x] 공통: 등록 버튼 연타 시 Firestore에 1개 문서만 생성되는지 검증 완료.
---